### PR TITLE
Ensure user doesn't install numpy in same directory as BLAS

### DIFF
--- a/00_Introduction.ipynb
+++ b/00_Introduction.ipynb
@@ -106,6 +106,7 @@
     "To install `numpy` linked against the OpenBLAS libraries we just compiled, first run the following\n",
     "\n",
     "```\n",
+    "cd ~/Downloads\n",
     "wget http://downloads.sourceforge.net/project/numpy/NumPy/1.9.2/numpy-1.9.2.zip\n",
     "unzip numpy-1.9.2.zip\n",
     "cd numpy-1.9.2\n",


### PR DESCRIPTION
Sorry about quick succession, last one for a bit. I have a colleague beside me following the instructions making mistakes along the way!