### PR TITLE
Avoid risk of running example code

### DIFF
--- a/02_MNIST_SLN.ipynb
+++ b/02_MNIST_SLN.ipynb
@@ -72,15 +72,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
    "source": [
+    "Example code for the above\n",
+    "```python\n",
     "# %load -s Linear mlp/layers.py\n",
-    "# DO NOT RUN THIS CELL (AS YOU WILL GET ERRORS), IT WAS JUST LOADED TO VISUALISE ABOVE COMMENTS\n",
     "class Linear(Layer):\n",
     "\n",
     "    def __init__(self, idim, odim,\n",
@@ -193,7 +192,8 @@
     "        self.b = params[1]\n",
     "\n",
     "    def get_name(self):\n",
-    "        return 'linear'\n"
+    "        return 'linear'\n",
+    "```"
    ]
   },
   {
@@ -295,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Put the example code in a markdown cell so that it can't be easily
accidentally run.