### PR TITLE
Implemented to_one_of_k function in MNISTDataProvider

### DIFF
--- a/mlp/data_providers.py
+++ b/mlp/data_providers.py
@@ -156,7 +156,10 @@ class MNISTDataProvider(DataProvider):
             to zero except for the column corresponding to the correct class
             which is equal to one.
         """
-        raise NotImplementedError()
+        one_of_k = np.zeros((np.shape(int_targets)[0],self.num_classes))
+        for n, l in enumerate(int_targets):
+            one_of_k[n][l] = 1
+        return one_of_k
 
 
 class MetOfficeDataProvider(DataProvider):


### PR DESCRIPTION
As it exists, the sample code in Exercise 1 of 01_introduction.ipynb calls MNISTDataProvider.to_one_of_k down the line, which throws a NotImplementedError.