### PR TITLE
Do not overwrite rng in DropoutLayer

### DIFF
--- a/mlp/layers.py
+++ b/mlp/layers.py
@@ -899,7 +899,6 @@ class DropoutLayer(StochasticLayer):
         assert incl_prob > 0. and incl_prob <= 1.
         self.incl_prob = incl_prob
         self.share_across_batch = share_across_batch
-        self.rng = rng
 
     def fprop(self, inputs, stochastic=True):
         """Forward propagates activations through the layer transformation.


### PR DESCRIPTION
If the parameter rng is `None`, `self.rng` it is set to the default generator in `StochasticLayer` but afterwards `self.rng` is overwritten with `rng  = None`.