### PR TITLE
Clarified use of 'conda/source activate'

### DIFF
--- a/notes/environment-set-up.md
+++ b/notes/environment-set-up.md
@@ -148,7 +148,7 @@ activate mlp
 
 When a environment is activated its name will be prepended on to the prompt which should now look something like `(mlp) [machine-name]:~$` on DICE.
 
-**You need to run this `source activate mlp` command every time you wish to activate the `mlp` environment in a terminal (for example at the beginning of each lab)**. When the environment is activated, the environment will be searched first when running commands so that e.g. `python` will launch the Python interpreter installed locally in the `mlp` environment rather than a system-wide version.
+**You need to run this `source activate mlp` or `conda activate mlp` command every time you wish to activate the `mlp` environment in a terminal (for example at the beginning of each lab)**. When the environment is activated, the environment will be searched first when running commands so that e.g. `python` will launch the Python interpreter installed locally in the `mlp` environment rather than a system-wide version.
 
 If you wish to deactivate an environment loaded in the current terminal e.g. to launch the system Python interpreter, you can run `source deactivate` (just `deactivate` on Windows).
 


### PR DESCRIPTION
Just clarified that you can use conda or source activate, as it says first to use `conda activate' and then to use `source activate'