### PR TITLE
Add .ipynb_checkpoints/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Conda stuff
+notebooks/.ipynb_checkpoints/


### PR DESCRIPTION
I've made this in my private fork, but now I need to re-do it every time I pull from this remote; so I'm submitting the change as PR here.

I think this line should be added because, according to [this stack overflow answer](https://stackoverflow.com/a/39997938/1814949), the files in `.ipynb_checkpoints` are temporary data and should therefore not be checked in to source control.