### PR TITLE
Fix bprop method definition in lab3 notebook

### DIFF
--- a/notebooks/03_Multiple_layer_models.ipynb
+++ b/notebooks/03_Multiple_layer_models.ipynb
@@ -93,7 +93,7 @@
     "    \\right).\n",
     "\\end{equation}\n",
     "\n",
-    "The `bprop` method takes an array of gradients with respect to the outputs $\\frac{\\partial y^{(b)}_k}{\\partial x^{(b)}_d}$ and applies a sum-product operation with the partial derivatives of each output with respect to each input $\\frac{\\partial \\bar{E}}{\\partial y^{(b)}_k}$, producing gradients with respect to the inputs of the layer $\\frac{\\partial \\bar{E}}{\\partial x^{(b)}_d}$.\n",
+    "The `bprop` method takes an array of gradients with respect to the outputs $\\frac{\\partial \\bar{E}}{\\partial y^{(b)}_k}$  and applies a sum-product operation with the partial derivatives of each output with respect to each input $\\frac{\\partial y^{(b)}_k}{\\partial x^{(b)}_d}$, producing gradients with respect to the inputs of the layer $\\frac{\\partial \\bar{E}}{\\partial x^{(b)}_d}$.\n",
     "\n",
     "For the affine transformation used in the `AffineLayer` implemented in lab 2, i.e. a forward propagation corresponding to \n",
     "\n",


### PR DESCRIPTION
If I understand the definition of bprop correctly, the name given to the gradients calculated are switched. 