### PR TITLE
Revert "Add `notebooks/.ipynb_checkpoints/` to .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,3 @@ docs/_build/
 
 # PyBuilder
 target/
-
-# Conda stuff
-notebooks/.ipynb_checkpoints/


### PR DESCRIPTION
Reverts CSTR-Edinburgh/mlpractical#74